### PR TITLE
Fix inset miscalculation

### DIFF
--- a/encodify/Classes/Utilities/Controller/ImageViewController.m
+++ b/encodify/Classes/Utilities/Controller/ImageViewController.m
@@ -133,7 +133,7 @@
     
     CGFloat insetLeft = 0.0;
     if (self.imageView.frame.size.width > self.scrollView.bounds.size.width) {
-        insetTop = 0;
+        insetLeft = 0;
     } else {
         insetLeft = (self.scrollView.bounds.size.width - self.imageView.frame.size.width) / 2;
     }


### PR DESCRIPTION
## Summary
- correct a typo in `ImageViewController` that caused vertical inset to be reset when the image width exceeded the scroll view's width

## Testing
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a31cdcf40833193c3bf467f290e1d