### PR TITLE
Fix typos and update headers

### DIFF
--- a/encodify/Classes/Encode/Controller/DecodeViewController.m
+++ b/encodify/Classes/Encode/Controller/DecodeViewController.m
@@ -36,7 +36,7 @@
 }
 
 - (void)encodeWithMorse:(NSString *)inputString textView:(UITextView *)textView {
-    [EncodifyXmorseBridge decode:inputString complection:^(NSString *string) {
+    [EncodifyXmorseBridge decode:inputString completion:^(NSString *string) {
         textView.text = string;
     }];
 }

--- a/encodify/Classes/Encode/Controller/EncodeViewController.m
+++ b/encodify/Classes/Encode/Controller/EncodeViewController.m
@@ -36,7 +36,7 @@
 }
 
 - (void)encodeWithMorse:(NSString *)inputString textView:(UITextView *)textView {
-    [EncodifyXmorseBridge encode:inputString complection:^(NSString *string) {
+    [EncodifyXmorseBridge encode:inputString completion:^(NSString *string) {
         textView.text = string;
     }];
 }

--- a/encodify/Classes/Encode/Module/Base64/EncodifyBase64.h
+++ b/encodify/Classes/Encode/Module/Base64/EncodifyBase64.h
@@ -1,6 +1,6 @@
 //
 //  EncodifyBase64.h
-//  ArgotAssistant
+//  encodify
 //
 //  Created by 朔 洪 on 16/1/9.
 //  Copyright © 2016年 Tuccuay. All rights reserved.

--- a/encodify/Classes/Encode/Module/Base64/EncodifyBase64.m
+++ b/encodify/Classes/Encode/Module/Base64/EncodifyBase64.m
@@ -1,6 +1,6 @@
 //
 //  EncodifyBase64.m
-//  ArgotAssistant
+//  encodify
 //
 //  Created by 朔 洪 on 16/1/9.
 //  Copyright © 2016年 Tuccuay. All rights reserved.

--- a/encodify/Classes/Encode/Module/Morse/EncodifyMorse.h
+++ b/encodify/Classes/Encode/Module/Morse/EncodifyMorse.h
@@ -1,6 +1,6 @@
 //
 //  EncodifyMores.h
-//  ArgotAssistant
+//  encodify
 //
 //  Created by 朔 洪 on 16/1/9.
 //  Copyright © 2016年 Tuccuay. All rights reserved.

--- a/encodify/Classes/Encode/Module/Morse/EncodifyMorse.m
+++ b/encodify/Classes/Encode/Module/Morse/EncodifyMorse.m
@@ -1,6 +1,6 @@
 //
 //  EncodifyMores.m
-//  ArgotAssistant
+//  encodify
 //
 //  Created by 朔 洪 on 16/1/9.
 //  Copyright © 2016年 Tuccuay. All rights reserved.

--- a/encodify/Classes/Encode/Module/Unicode/EncodifyUnicode.h
+++ b/encodify/Classes/Encode/Module/Unicode/EncodifyUnicode.h
@@ -1,6 +1,6 @@
 //
 //  EncodifyUnicode.h
-//  ArgotAssistant
+//  encodify
 //
 //  Created by 朔 洪 on 16/1/9.
 //  Copyright © 2016年 Tuccuay. All rights reserved.

--- a/encodify/Classes/Encode/Module/Unicode/EncodifyUnicode.m
+++ b/encodify/Classes/Encode/Module/Unicode/EncodifyUnicode.m
@@ -1,6 +1,6 @@
 //
 //  EncodifyUnicode.m
-//  ArgotAssistant
+//  encodify
 //
 //  Created by 朔 洪 on 16/1/9.
 //  Copyright © 2016年 Tuccuay. All rights reserved.

--- a/encodify/Classes/Encode/Module/XmorseBridge/EncodifyXmorseBridge.h
+++ b/encodify/Classes/Encode/Module/XmorseBridge/EncodifyXmorseBridge.h
@@ -12,7 +12,7 @@ typedef void(^xmorseBridge)(NSString *string);
 
 @interface EncodifyXmorseBridge : NSObject
 
-+ (void)encode:(NSString *)string complection:(xmorseBridge)complection;
-+ (void)decode:(NSString *)string complection:(xmorseBridge)complection;
++ (void)encode:(NSString *)string completion:(xmorseBridge)completion;
++ (void)decode:(NSString *)string completion:(xmorseBridge)completion;
 
 @end

--- a/encodify/Classes/Encode/Module/XmorseBridge/EncodifyXmorseBridge.m
+++ b/encodify/Classes/Encode/Module/XmorseBridge/EncodifyXmorseBridge.m
@@ -12,20 +12,20 @@
 @implementation EncodifyXmorseBridge
 
 + (void)encode:(NSString *)string
-   complection:(xmorseBridge)complection {
-    
-    [self morseMethod:@"encode" string:string complection:complection];
+   completion:(xmorseBridge)completion {
+
+    [self morseMethod:@"encode" string:string completion:completion];
 }
 
 + (void)decode:(NSString *)string
-   complection:(xmorseBridge)complection {
-    
-    [self morseMethod:@"decode" string:string complection:complection];
+   completion:(xmorseBridge)completion {
+
+    [self morseMethod:@"decode" string:string completion:completion];
 }
 
 + (void)morseMethod:(NSString *)method
              string:(NSString *)string
-        complection:(xmorseBridge)complection {
+        completion:(xmorseBridge)completion {
     
     NSString *xmorseMinPath = [[NSBundle mainBundle]
                                pathForResource:@"xmorse.min" ofType:@"js"];
@@ -46,7 +46,7 @@
     [context evaluateScript:encodifyXmorseBridgeString];
     
     context[@"callback"] = ^(NSString *text) {
-        complection(text);
+        completion(text);
     };
     
     JSValue *morse = context[method];

--- a/encodify/Classes/Utilities/Controller/ImageDecodeViewController.m
+++ b/encodify/Classes/Utilities/Controller/ImageDecodeViewController.m
@@ -55,7 +55,7 @@
     NSString *string = self.textView.text;
     
     
-    NSData *data = [[NSData alloc] initWithBase64EncodedString:string options:NSDataBase64DecodingIgnoreUnknownCharacters];;
+    NSData *data = [[NSData alloc] initWithBase64EncodedString:string options:NSDataBase64DecodingIgnoreUnknownCharacters];
     if (data == nil) {
         [EToast showStatus:@"Decode failure."];
         return;


### PR DESCRIPTION
## Summary
- rename `complection` parameter to `completion`
- fix stray semicolon in image decode
- update header comments with current project name

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684a31cd98908331b41b00b83088abf5