### PR TITLE
Add CI workflow for PRs

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  pull_request:
+    branches: ["**"]
+
+jobs:
+  build:
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '2.7'
+
+      - name: Install CocoaPods
+        run: |
+          gem install cocoapods
+          pod install
+
+      - name: Build and Test
+        run: |
+          xcodebuild clean test \
+            -workspace encodify.xcworkspace \
+            -scheme encodify \
+            -sdk iphonesimulator \
+            -destination 'platform=iOS Simulator,name=iPhone 11,OS=latest' \
+            CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.7'
+          ruby-version: '3.2'
 
       - name: Install CocoaPods
         run: |


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build and test PRs on macOS

## Testing
- `npm test` *(fails: package.json missing)*
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a6f22267083319a66ce35a3dd301d